### PR TITLE
fix: update branch references from master to main in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
This pull request updates the CI configuration in `.github/workflows/main.yml` to align with the branch renaming from `master` to `main`.

CI configuration updates:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L6-R9): Updated the branch references in the `push` and `pull_request` triggers from `master` to `main`.