### PR TITLE
Docs: Clarify Zod v3/v4 import paths and add attribution

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:
@@ -48,12 +48,12 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
-          
+
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -61,18 +61,17 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,26 +39,25 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/readme.md
+++ b/readme.md
@@ -59,12 +59,27 @@ npm install @coji/zodix zod
 
 ### Zod Version Compatibility
 
-Zodix supports both Zod v3 and v4:
+Zodix supports both Zod v3 and v4 through separate import paths:
 
-- **Zod v3**: Requires `zod@^3.25.0` or later
-- **Zod v4**: Fully compatible with `zod@^4.0.0`
+- **Zod v3**: Use `@coji/zodix` (requires `zod@^3.25.0` or later)
+- **Zod v4**: Use `@coji/zodix/v4` (requires `zod@^4.0.0`)
 
-Your existing Zod schemas will work regardless of which version you're using. Zodix automatically detects and handles both versions transparently.
+```ts
+// For Zod v3
+import { zx } from '@coji/zodix'
+
+// For Zod v4
+import { zx } from '@coji/zodix/v4'
+```
+
+### Migration Guide
+
+Upgrading from Zod v3 to v4? Follow these steps:
+
+1. Update your Zod dependency: `npm install zod@^4.0.0`
+2. Review and migrate your Zod schemas if needed - see [Zod v4 Changelog](https://zod.dev/v4/changelog) for breaking changes
+3. Change your Zodix imports from `@coji/zodix` to `@coji/zodix/v4`
+4. That's it! 🎉
 
 ## Usage
 
@@ -234,7 +249,7 @@ Because `FormData` and `URLSearchParams` serialize all values to strings, you of
 - `"3.14"` → `3.14`
 - `"notanumber"` → throws `ZodError`
 
-See [the tests](/src/schemas.test.ts) for more details.
+See [the tests](/src/schemas.v4.test.ts) for more details.
 
 ### Usage
 
@@ -267,17 +282,17 @@ parsed = {
 
 ### How It Works
 
-Zodix uses an intelligent compatibility layer that:
+Zodix provides separate import paths for Zod v3 and v4 compatibility:
 
-1. **Automatically detects** which version of Zod you're using
-2. **Transparently handles** parsing and validation for both versions
-3. **Requires no code changes** when upgrading from Zod v3 to v4
+1. **Use the appropriate import path** based on your Zod version
+2. **Full type safety** is maintained for both versions
+3. **Same API** across both versions - only the import path changes
 
 ### Using with Zod v3
 
 ```ts
 import { z } from 'zod' // v3.x
-import { zx } from '@coji/zodix'
+import { zx } from '@coji/zodix' // Default path for v3
 
 const schema = z.object({
   name: z.string(),
@@ -285,7 +300,7 @@ const schema = z.object({
 })
 
 export async function loader({ params }: Route.LoaderArgs) {
-  const data = zx.parseParams(params, schema) // Works perfectly!
+  const data = zx.parseParams(params, schema) // Works with Zod v3!
 }
 ```
 
@@ -293,7 +308,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 
 ```ts
 import { z } from 'zod' // v4.x
-import { zx } from '@coji/zodix'
+import { zx } from '@coji/zodix/v4' // Use v4 path
 
 const schema = z.object({
   name: z.string(),
@@ -301,17 +316,9 @@ const schema = z.object({
 })
 
 export async function loader({ params }: Route.LoaderArgs) {
-  const data = zx.parseParams(params, schema) // Also works perfectly!
+  const data = zx.parseParams(params, schema) // Works with Zod v4!
 }
 ```
-
-### Migration Guide
-
-Upgrading from Zod v3 to v4? No changes needed in your Zodix code!
-
-1. Update your Zod dependency: `npm install zod@^4.0.0`
-2. Your existing Zodix code continues to work without modification
-3. That's it! 🎉
 
 ## Extras
 
@@ -367,3 +374,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
 }
 ```
+
+## Acknowledgments
+
+This project is a fork of [rileytomasek/zodix](https://github.com/rileytomasek/zodix). Thanks to Riley Tomasek for creating the original Zodix library.


### PR DESCRIPTION

This pull request updates the `README.md` to provide clearer instructions on how to use Zodix with different versions of Zod. It also adds an acknowledgment to the original creator of the library.

**Key Changes:**

- **Explicit Import Paths:** The documentation now clearly states that Zod v3 and Zod v4 require separate import paths:
    - `import { zx } from '@coji/zodix'` for Zod v3
    - `import { zx } from '@coji/zodix/v4'` for Zod v4
- **Updated Migration Guide:** The migration guide has been corrected to instruct users to update their import paths when upgrading from Zod v3 to v4.
- **Revised Code Examples:** All usage examples in the README have been updated to reflect the correct import paths.
- **Added Acknowledgments:** A new section has been added to credit `rileytomasek/zodix` as the original source of the project.
- **Minor Cleanup:** Removed trailing whitespace from GitHub Actions workflow files.