### PR TITLE
fix: exclude CHANGELOG.md from prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 pnpm-lock.yaml
+CHANGELOG.md


### PR DESCRIPTION
## Summary

Fixes the release workflow failure caused by Prettier format check on auto-generated CHANGELOG.md.

### Problem

The release-please workflow failed with:
```
[warn] CHANGELOG.md
[warn] Code style issues found in 1 file. Run Prettier with --write to fix.
```

### Solution

Add `CHANGELOG.md` to `.prettierignore` because:
- CHANGELOG.md is automatically generated by release-please
- Its formatting should not be checked or modified by Prettier
- This is a common practice for auto-generated files

### Testing

After merging, the next release will pass the format check step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude CHANGELOG.md from Prettier processing, ensuring changelog entries remain unmodified during automatic formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->